### PR TITLE
修复服务器列表只能搜索到使用了mod的服的bug

### DIFF
--- a/api/thirdPartyApi.go
+++ b/api/thirdPartyApi.go
@@ -46,7 +46,19 @@ func (t *ThirdPartyApi) GetDstHomeServerList(c *gin.Context) {
 	param := third.NewDstHomeServerParam()
 	c.Bind(param)
 
-	bytesData, err := json.Marshal(param)
+	query_data := map[string]any{}
+	query_data["page"] = param.Page
+	query_data["paginate"] = param.Paginate
+	query_data["sort_type"] = param.SortType
+	query_data["sort_way"] = param.SortWay
+	query_data["search_type"] = param.Search_type
+	query_data["search_content"] = param.Search_content
+	if param.Mod != "" {
+		// 不区分是否使用mod
+		query_data["mod"] = param.Mod
+	}
+
+	bytesData, err := json.Marshal(query_data)
 	if err != nil {
 		log.Println("josn 解析异常")
 	}

--- a/vo/third/DstHomeServerParam.go
+++ b/vo/third/DstHomeServerParam.go
@@ -7,7 +7,7 @@ type DstHomeServerParam struct {
 	SortWay        int    `json:"sort_way"`
 	Search_type    int    `json:"search_type"`
 	Search_content string `json:"search_content"`
-	Mod            int    `json:"mod"`
+	Mod            string `json:"mod"`
 }
 
 func NewDstHomeServerParam() *DstHomeServerParam {


### PR DESCRIPTION
使用的服务器列表接口在不存在mod参数时为`任意`，mod参数为int值时直接解析为json默认赋值0(即无mod)，无法区分是否为空值