### PR TITLE
fix:为文档中的部署命令添加--init选项，以支持docker stop命令

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -20,7 +20,7 @@
 
 ```
 docker pull hujinbo23/dst-admin-go:1.2.7
-docker run -d -p8082:8082 hujinbo23/dst-admin-go:1.2.7
+docker run -d --init -p 8082:8082 hujinbo23/dst-admin-go:1.2.7
 ```
 
 **路径参考**


### PR DESCRIPTION
当前Docker部署该项目后使用docker stop命令需要等待10s才能关闭容器（其实就是时间太长了变成docker kill了）。随希望能加个--init选项