### PR TITLE
修复wanip获取逻辑，调整接口

### DIFF
--- a/service/gameArchiveServer.go
+++ b/service/gameArchiveServer.go
@@ -134,6 +134,7 @@ func (d *GameArchive) GetPublicIP() (string, error) {
 		"https://myip.ipip.net",
 		"https://cdid.c-ctrip.com/model-poc2/h", // 某携程api，IPv6优先
 		// == 以下优先返回国外ip ==
+		"https://lobby-v2.klei.com/lobby/getIP", // Klei官方api
 		"https://api.ipify.org",
 		"https://ifconfig.me/ip",
 		"https://checkip.amazonaws.com",
@@ -190,7 +191,7 @@ func (d *GameArchive) GetPrivateIP() (string, error) {
 		}
 	}
 
-	return "127.0.0.1", nil
+	return "", nil
 }
 
 func (d *GameArchive) getSubPathLevel(rootP, curPath string) int {


### PR DESCRIPTION
1. 调整接口调用逻辑，改为api静态列表遍历；
2. 新增ip查询api列表，包含Klei官方api和公共第三方api，优先返回国内公网ip；
3. 新增ip校验逻辑，过滤ipv6；
4. 新增：如果wanip为空，就返回局域网ip

#101 