### PR TITLE
fix: handle Steam update retries and preserve console command quotes

### DIFF
--- a/internal/pkg/utils/shellUtils/shellUitls.go
+++ b/internal/pkg/utils/shellUtils/shellUitls.go
@@ -26,17 +26,26 @@ func ExecuteCommand(command string) (string, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err := cmd.Run()
+	stdoutText := out.String()
+	stderrText := stderr.String()
 
 	if err != nil {
-		return "", fmt.Errorf("run command error: %v, ERROR: %s", err, stderr.String())
-	}
-	if stderr.String() != "" {
-		if out.String() != "" {
-			return out.String() + "\n" + stderr.String(), nil
+		combined := stdoutText
+		if stderrText != "" {
+			if combined != "" {
+				combined += "\n"
+			}
+			combined += stderrText
 		}
-		return stderr.String(), nil
+		return combined, fmt.Errorf("run command error: %v, ERROR: %s", err, combined)
 	}
-	return out.String(), nil
+	if stderrText != "" {
+		if stdoutText != "" {
+			return stdoutText + "\n" + stderrText, nil
+		}
+		return stderrText, nil
+	}
+	return stdoutText, nil
 }
 
 // 执行shell命令

--- a/internal/pkg/utils/shellUtils/shellUitls.go
+++ b/internal/pkg/utils/shellUtils/shellUitls.go
@@ -31,7 +31,10 @@ func ExecuteCommand(command string) (string, error) {
 		return "", fmt.Errorf("run command error: %v, ERROR: %s", err, stderr.String())
 	}
 	if stderr.String() != "" {
-		return "", fmt.Errorf("exec command error: %s", stderr.String())
+		if out.String() != "" {
+			return out.String() + "\n" + stderr.String(), nil
+		}
+		return stderr.String(), nil
 	}
 	return out.String(), nil
 }

--- a/internal/pkg/utils/shellUtils/shellUitls_test.go
+++ b/internal/pkg/utils/shellUtils/shellUitls_test.go
@@ -1,0 +1,30 @@
+package shellUtils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExecuteCommandAllowsSuccessfulStderr(t *testing.T) {
+	out, err := ExecuteCommand(`printf 'normal output'; printf 'informational stderr' >&2`)
+	if err != nil {
+		t.Fatalf("ExecuteCommand returned unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "normal output") || !strings.Contains(out, "informational stderr") {
+		t.Fatalf("combined output missing stdout/stderr: %q", out)
+	}
+}
+
+func TestExecuteCommandIncludesStdoutAndStderrOnFailure(t *testing.T) {
+	out, err := ExecuteCommand(`printf 'stdout before failure'; printf 'stderr before failure' >&2; exit 8`)
+	if err == nil {
+		t.Fatalf("ExecuteCommand returned nil error for failing command, output=%q", out)
+	}
+	if !strings.Contains(out, "stdout before failure") || !strings.Contains(out, "stderr before failure") {
+		t.Fatalf("output missing stdout/stderr: %q", out)
+	}
+	errText := err.Error()
+	if !strings.Contains(errText, "exit status 8") || !strings.Contains(errText, "stdout before failure") || !strings.Contains(errText, "stderr before failure") {
+		t.Fatalf("error missing exit status or combined output: %q", errText)
+	}
+}

--- a/internal/service/game/linux_process.go
+++ b/internal/service/game/linux_process.go
@@ -6,6 +6,7 @@ import (
 	"dst-admin-go/internal/service/dstConfig"
 	"dst-admin-go/internal/service/levelConfig"
 	"log"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -218,9 +219,18 @@ func (p *LinuxProcess) Status(clusterName, levelName string) (bool, error) {
 }
 
 func (p *LinuxProcess) Command(clusterName, levelName, command string) error {
-	cmd := "screen -S \"" + p.SessionName(clusterName, levelName) + "\" -p 0 -X stuff \"" + command + "\\n\""
-	_, err := shellUtils.Shell(cmd)
-	return err
+	// Do not route remote console commands through `sh -c`: panel commands often
+	// contain Lua string quotes (for example c_give("cutgrass", 1)).  Shell
+	// parsing strips or reinterprets those quotes before `screen` receives them,
+	// causing DST to execute c_give(cutgrass, 1) or print(FOO) instead of the
+	// intended Lua.  Pass argv directly so the command text is delivered exactly.
+	return exec.Command(
+		"screen",
+		"-S", p.SessionName(clusterName, levelName),
+		"-p", "0",
+		"-X", "stuff",
+		command+"\n",
+	).Run()
 }
 
 func (p *LinuxProcess) PsAuxSpecified(clusterName, levelName string) DstPsAux {

--- a/internal/service/update/linux_update.go
+++ b/internal/service/update/linux_update.go
@@ -4,6 +4,8 @@ import (
 	"dst-admin-go/internal/pkg/utils/shellUtils"
 	"dst-admin-go/internal/service/dstConfig"
 	"log"
+	"os"
+	"path/filepath"
 )
 
 type LinuxUpdate struct {
@@ -27,5 +29,32 @@ func (u LinuxUpdate) Update(clusterName string) error {
 	}
 	log.Println("正在更新游戏", "cluster: ", clusterName, "command: ", updateCommand)
 	_, err = shellUtils.Shell(updateCommand)
-	return err
+	if err == nil {
+		return nil
+	}
+
+	log.Println("更新游戏失败，清理 Steam 下载缓存后重试一次", "cluster: ", clusterName, "error: ", err)
+	cleanupSteamDownloadCache(config)
+	_, retryErr := shellUtils.Shell(updateCommand)
+	if retryErr != nil {
+		return retryErr
+	}
+	return nil
+}
+
+func cleanupSteamDownloadCache(config dstConfig.DstConfig) {
+	dstInstallDir := config.Force_install_dir
+	if config.Beta == 1 {
+		dstInstallDir += "-beta"
+	}
+	paths := []string{
+		filepath.Join(dstInstallDir, "steamapps", "downloading"),
+		filepath.Join(dstInstallDir, "steamapps", "temp"),
+		filepath.Join(dstInstallDir, "steamapps", "appmanifest_343050.acf"),
+	}
+	for _, path := range paths {
+		if err := os.RemoveAll(path); err != nil {
+			log.Println("清理 Steam 下载缓存失败", "path: ", path, "error: ", err)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Fixes two reported runtime issues:

- Fixes #155: Docker game updates can fail with `exit status 8` after Steam cache/download state becomes stale.
- Fixes #164: remote console commands such as `c_give("cutgrass", 1)` can lose Lua quotes before reaching DST, breaking TooManyItemsPlus and custom commands.

## Changes

### #155 Steam update failure

- `shellUtils.ExecuteCommand` now treats stderr as informational when the command exits successfully, instead of failing just because SteamCMD printed to stderr.
- Failed Linux game updates now clean Steam download/cache state once and retry:
  - `steamapps/downloading`
  - `steamapps/temp`
  - `steamapps/appmanifest_343050.acf`

### #164 quoted remote console commands

- Linux remote console command delivery no longer routes `screen -X stuff` through `sh -c`.
- `LinuxProcess.Command` now calls `exec.Command("screen", ... argv ...)`, preserving command text exactly, including nested Lua quotes.
- This prevents commands like `print("FOO")` and `c_give("goldnugget", 3)` from being transformed into invalid Lua such as `print(FOO)` or `c_give(goldnugget, 3)`.

## Compatibility / language check

- Backend changes are Linux-only where appropriate (`LinuxUpdate`, `LinuxProcess`) and leave Windows update/process implementations untouched.
- Command passing now uses argv rather than shell parsing, so it is safer for all Lua command strings containing quotes, spaces, Chinese/Japanese/Korean text, or other non-shell content.
- Frontend command generation compatibility is handled in the paired web PR by sending normal Lua quotes instead of shell-escaped quotes.

## Test plan

Automated:

- `go test ./internal/pkg/utils/shellUtils ./internal/service/game ./internal/service/update`
- `go test $(go list ./... 2>/dev/null | grep -v '^dst-admin-go/static/template$')`

Notes:

- `go test ./...` still attempts to compile `static/template/test.go`, which imports missing package `dst-admin-go/vo`; that pre-existing template package is excluded in the full-package verification command above.

Manual / live DST verification performed on a running local DST server:

- Before fix, sending `print("ISSUE164_QUOTE_TEST")` arrived in `server_log.txt` as `RemoteCommandInput: "print(ISSUE164_QUOTE_TEST)"` and Lua reported `variable ... is not declared`.
- After fix, the same command arrived as `RemoteCommandInput: "print("ISSUE164_QUOTE_TEST")"` and printed the marker successfully.
- Verified player-targeted item grant with:
  - `ThePlayer = UserToPlayer("KU_eK2T5TeZ")`
  - `c_give("goldnugget", 3)`
  - `ThePlayer = nil`
- `server_log.txt` confirmed three `goldnugget` grants and success marker output.

Paired frontend PR: https://github.com/carrot-hu23/dst-manage-web2/pull/9

